### PR TITLE
fix(accoridon): remove unneeded card-title class

### DIFF
--- a/src/accordion/accordion-group.component.ts
+++ b/src/accordion/accordion-group.component.ts
@@ -16,7 +16,7 @@ import { AccordionComponent } from './accordion.component';
   template: `
 <div class="panel card" [ngClass]="panelClass">
   <div class="panel-heading card-header" role="tab" (click)="toggleOpen($event)">
-    <div class="panel-title card-title">
+    <div class="panel-title">
       <div role="button" class="accordion-toggle" [attr.aria-expanded]="isOpen">
         <div *ngIf="heading"[ngClass]="{'text-muted': isDisabled}">{{heading}}</div>
         <ng-content select="[accordion-heading]"></ng-content>


### PR DESCRIPTION
This is only relevant with bs4.
You can see [here](http://valor-software.com/ngx-bootstrap/index-bs4.html#/accordion) that the headers are bigger than their bs3 counterparts and that the titles aren't vertically centered.
This is because of the `card-title` class which adds a margin under those titles. This class is actually used wrongly here since it serves other purposes: adding a style on `<h*>` elements in the panel **itself** (not the header). See [the docs](http://v4-alpha.getbootstrap.com/components/card/#header-and-footer)  on Card Components.